### PR TITLE
BUILD/cc_image: use debian testing as base image

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -116,6 +116,7 @@ load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
 cc_image(
     name = "foodfinder_image",
     binary = ":foodfinder",
+    base = "@official_debian_bullseye_slim//image",
 )
 
 cc_image(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -112,3 +112,12 @@ load(
 )
 
 _cc_image_repos()
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+container_pull(
+            name = "official_debian_bullseye_slim",
+            registry = "index.docker.io",
+            repository = "library/debian",
+            tag = "bullseye-20200607-slim",
+)


### PR DESCRIPTION
Provides:
- glibc 2.30
- libstdc++ 3.4.28

/cc @ymotongpoo