### PR TITLE
add docker instructions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -122,9 +122,11 @@ cc_image(
 cc_image(
     name = "foodsupplier_image",
     binary = ":foodsupplier",
+    base = "@official_debian_bullseye_slim//image",
 )
 
 cc_image(
     name = "foodvendor_image",
     binary = ":foodvendor",
+    base = "@official_debian_bullseye_slim//image",
 )

--- a/README.md
+++ b/README.md
@@ -43,3 +43,27 @@ sh scripts/foodvendor.sh
 sh scripts/foodsupplier.sh
 ```
 **Note** - Make sure to run the FoodSupplier and FoodVendor services BEFORE running the FoodFinder service.
+
+## How to use with Docker?
+
+### Building
+
+
+```
+bazel build :foodsupplier_image.tar
+docker load -i ./bazel-bin/foodsupplier_image.tar
+bazel build :foodvendor_image.tar
+docker load -i ./bazel-bin/foodvendor_image.tar
+bazel build :foodfinder_image.tar
+docker load -i ./bazel-bin/foodfinder_image.tar
+```
+
+### Running
+
+
+```
+docker create network fooddemo
+docker run --name foodsupplier --network fooddemo bazel:foodsupplier_image
+docker run --name foodvendor --network fooddemo bazel:foodvendor_image
+docker run -ti --name foodfinder --network fooddemo bazel:foodfinder_image
+```

--- a/foodfinder.cc
+++ b/foodfinder.cc
@@ -306,11 +306,11 @@ void RungRPC() {
     suppliers_per_query_view_descriptor.RegisterForExport();
 
     // Create a channel to the FoodSupplier service to send RPCs over.
-    std::shared_ptr<grpc::Channel> foodsupplier_channel = grpc::CreateChannel("127.0.0.1:9001", grpc::InsecureChannelCredentials());
+    std::shared_ptr<grpc::Channel> foodsupplier_channel = grpc::CreateChannel("foodsupplier:9001", grpc::InsecureChannelCredentials());
     std::unique_ptr<FoodSystem::Stub> foodsupplier_stub = FoodSystem::NewStub(foodsupplier_channel);
 
     // Create a channel to the FoodVendor service to send RPCs over.
-    std::shared_ptr<grpc::Channel> foodvendor_channel = grpc::CreateChannel("127.0.0.1:9002", grpc::InsecureChannelCredentials());	
+    std::shared_ptr<grpc::Channel> foodvendor_channel = grpc::CreateChannel("foodvendor:9002", grpc::InsecureChannelCredentials());	
     std::unique_ptr<FoodSystem::Stub> foodvendor_stub = FoodSystem::NewStub(foodvendor_channel);
 
     // Setup Always sampler so that every span is processed and exported

--- a/foodsupplier.cc
+++ b/foodsupplier.cc
@@ -27,7 +27,7 @@ grpc::Status FoodSupplier::GetSuppliers(grpc::ServerContext* context,
 
 void RunServer() {
   // The server address of the form "address:port"
-  std::string server_address("127.0.0.1:9001");
+  std::string server_address("0.0.0.0:9001");
   FoodSupplier service;
 
   // Register the OpenCensus gRPC plugin to enable stats and tracing in gRPC.

--- a/foodvendor.cc
+++ b/foodvendor.cc
@@ -27,7 +27,7 @@ ServerImpl::~ServerImpl() {
 
 
 void ServerImpl::Run() {
-    std::string server_address("127.0.0.1:9002");
+    std::string server_address("0.0.0.0:9002");
 
     ServerBuilder builder;
 


### PR DESCRIPTION
- bind daemons on 0.0.0.0
- create user defined network bridge
- connect to container by hostname
- add docker instructions

Note: it would be probably better for `foodfinder` to take the hostname and port of dependent grpc server as command line arguments.

/cc @ymotongpoo